### PR TITLE
Now the user is limited to has up to ten Targets.

### DIFF
--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -2,6 +2,15 @@ class Target < ApplicationRecord
   belongs_to :topic
   belongs_to :user
 
+  MAX_TARGET_LIMIT = 10
+
   validates :title, :radius, :latitude, :longitude, presence: true
   validates :radius, numericality: { greater_than: 0, less_than_or_equal_to: 1000 }
+  validate :targets_per_user_limit, on: :create
+
+  def targets_per_user_limit
+    return if user.targets.size < MAX_TARGET_LIMIT
+
+    errors.add(:target, I18n.t('api.models.target.errors.reached_limit', max: MAX_TARGET_LIMIT))
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,7 @@ en:
       invalid_content_type: 'Invalid content type header'
       invalid_credentials: 'Invalid login credentials. Please try again.'
       email_not_confirmed: "A confirmation email was sent to your account at '%{email}'. You must follow the instructions in the email before your account can be activated"
+    models:
+      target:
+        errors:
+          reached_limit: 'You reached the %{max} limit of targets! Delete one if you want to create another.'

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -2,4 +2,8 @@ module Helpers
   def auth_headers
     user.create_new_auth_token
   end
+
+  def json
+    JSON.parse(response.body).with_indifferent_access
+  end
 end

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'POST /api/v1/users/sign_in', type: :request do
 
     it 'returns the user' do
       subject
-      expect(response.body).to include_json(
+      expect(json).to include_json(
         user: {
           id: user.id,
           email: user.email,
@@ -54,7 +54,7 @@ RSpec.describe 'POST /api/v1/users/sign_in', type: :request do
     it 'returns the error message' do
       subject
       error_msg = I18n.t('api.errors.invalid_credentials')
-      expect(response.body).to include_json(errors: [error_msg])
+      expect(json).to include_json(errors: [error_msg])
     end
 
     it 'returns a unauthorized status' do
@@ -78,7 +78,7 @@ RSpec.describe 'POST /api/v1/users/sign_in', type: :request do
     it 'returns the error message' do
       subject
       error_msg = I18n.t('api.errors.email_not_confirmed', email: user_not_confirmed.email)
-      expect(response.body).to include_json(errors: [error_msg])
+      expect(json).to include_json(errors: [error_msg])
     end
 
     it 'returns a unauthorized status' do

--- a/spec/requests/api/v1/targets/show_spec.rb
+++ b/spec/requests/api/v1/targets/show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'GET /api/v1/Targets/:id', type: :request do
 
       it 'returns the target as a json' do
         subject
-        expect(response.body).to include_json(
+        expect(json).to include_json(
           target: {
             topic_id: topic.id,
             title: target.title,
@@ -35,7 +35,7 @@ RSpec.describe 'GET /api/v1/Targets/:id', type: :request do
 
       it 'returns the error messages as a json' do
         subject
-        expect(response.body).to include_json(error: 'Record not found')
+        expect(json).to include_json(error: 'Record not found')
       end
 
       it 'returns a not found status' do
@@ -51,7 +51,7 @@ RSpec.describe 'GET /api/v1/Targets/:id', type: :request do
 
     it 'returns the error messages as a json' do
       subject
-      expect(response.body).to include_json(errors: [I18n.t('devise.failure.unauthenticated')])
+      expect(json).to include_json(errors: [I18n.t('devise.failure.unauthenticated')])
     end
 
     it 'returns a unauthorized status' do


### PR DESCRIPTION
- Validation was added, now a user has a limit of 10 targets.

- Spect was added to test the limit of targets when a user add a new one.

- A helper was added to call json only instead of response.body, and replaced in each spec.  