### PR TITLE
Add new action in target controller

### DIFF
--- a/app/controllers/api/v1/targets_controller.rb
+++ b/app/controllers/api/v1/targets_controller.rb
@@ -1,6 +1,10 @@
 module Api
   module V1
     class TargetsController < Api::V1::ApiController
+      def new
+        @topics = Topic.all
+      end
+
       def create
         @target = current_user.targets.create!(target_params)
         render :show, status: :created

--- a/app/views/api/v1/targets/new.json.jbuilder
+++ b/app/views/api/v1/targets/new.json.jbuilder
@@ -1,0 +1,3 @@
+json.topics(@topics) do |topic|
+  json.extract! topic, :id, :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :targets, only: %i[create show index destroy]
+      resources :targets, only: %i[create show index destroy new]
     end
   end
 end

--- a/spec/requests/api/v1/targets/new_spec.rb
+++ b/spec/requests/api/v1/targets/new_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/targets/new', type: :request do
+  subject { get new_api_v1_target_url, headers: headers, as: :json }
+
+  context 'with logged-in user' do
+    let!(:topics) { create_list(:topic, 7) }
+    let(:user) { create(:user) }
+    let(:headers) { auth_headers }
+
+    context 'when the request is valid' do
+      it 'returns the collection of topics as a json' do
+        subject
+        topics_collection = topics.map do |topic|
+          {
+            id: topic.id,
+            name: topic.name
+          }
+        end
+
+        expect(json).to include_json(
+          topics: topics_collection
+        )
+      end
+
+      it 'returns a success status' do
+        subject
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when the request is valid and there are no topics' do
+      it 'returns empty topics collection' do
+        subject
+        expect(json).to include_json(topics: [])
+      end
+
+      it 'returns a success status' do
+        subject
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  context 'when the user is not authenticated' do
+    let(:headers) { nil }
+
+    it 'returns the error messages as a json' do
+      subject
+      expect(json).to include_json(errors: [I18n.t('devise.failure.unauthenticated')])
+    end
+
+    it 'returns an unauthorized status' do
+      subject
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
- New action controller was added to index topics, they are needed to create a new target.  That is the only one request that I need from Topic so I don't need to create a Topic Controller. 